### PR TITLE
Fix BP output envelope after post-clamp validation

### DIFF
--- a/src/modules/vital-signs/BloodPressureProcessor.ts
+++ b/src/modules/vital-signs/BloodPressureProcessor.ts
@@ -203,11 +203,14 @@ export class BloodPressureProcessor {
       sbp = this.lastSBP * (1 - this.EMA_ALPHA) + sbp * this.EMA_ALPHA;
       dbp = this.lastDBP * (1 - this.EMA_ALPHA) + dbp * this.EMA_ALPHA;
     }
+
+    const bounded = this.clampAndValidateOutputPair(sbp, dbp);
+    if (!bounded) return insufficient;
+    sbp = bounded.sbp;
+    dbp = bounded.dbp;
     this.lastSBP = sbp;
     this.lastDBP = dbp;
 
-    sbp = Math.max(85, Math.min(180, sbp));
-    dbp = Math.max(50, Math.min(110, dbp));
     const map = dbp + (sbp - dbp) / 3;
     const featureQuality = this.assessFeatureQuality(mf, useCycles.length);
     const confStr = this.assessConfidence(featureQuality, useCycles.length);
@@ -272,11 +275,14 @@ export class BloodPressureProcessor {
       sbp = this.lastSBP * (1 - this.EMA_ALPHA) + sbp * this.EMA_ALPHA;
       dbp = this.lastDBP * (1 - this.EMA_ALPHA) + dbp * this.EMA_ALPHA;
     }
+
+    const bounded = this.clampAndValidateOutputPair(sbp, dbp);
+    if (!bounded) return insufficient;
+    sbp = bounded.sbp;
+    dbp = bounded.dbp;
     this.lastSBP = sbp;
     this.lastDBP = dbp;
 
-    sbp = Math.max(85, Math.min(180, sbp));
-    dbp = Math.max(50, Math.min(110, dbp));
     const map = dbp + (sbp - dbp) / 3;
     const featureQuality = this.assessFeatureQuality(mf, useCycles.length);
     const confidence = this.assessConfidence(featureQuality, useCycles.length);
@@ -362,6 +368,16 @@ export class BloodPressureProcessor {
     if (featureQuality >= 42 && cycleCount >= 3) return 'MEDIUM';
     if (featureQuality >= 18 && cycleCount >= 1) return 'LOW';
     return 'INSUFFICIENT';
+  }
+
+  private clampAndValidateOutputPair(sbp: number, dbp: number): { sbp: number; dbp: number } | null {
+    const clampedSBP = Math.max(85, Math.min(180, sbp));
+    const clampedDBP = Math.max(50, Math.min(110, dbp));
+    const pulsePressure = clampedSBP - clampedDBP;
+    if (pulsePressure < 15 || pulsePressure > 100) {
+      return null;
+    }
+    return { sbp: clampedSBP, dbp: clampedDBP };
   }
 
   reset(): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes `BloodPressureProcessor` to re-validate pulse pressure **after** independent SBP/DBP clamping.
- Applies the same guard in both `estimate()` and `process()` paths.
- Returns `INSUFFICIENT` when clamped pair violates physiological pulse-pressure envelope (`<15` or `>100`).

## Why
Independent clamping can produce an invalid pair (e.g. `SBP=180`, `DBP=50`, `PP=130`). Previously this escaped validation and violated physiological constraints.

## Scope
- `src/modules/vital-signs/BloodPressureProcessor.ts`

## Validation plan
- Reproduce with controlled synthetic input + injected calibration offset that forces post-clamp `PP > 100`.
- Verify output is now withheld (`INSUFFICIENT`) instead of emitting an invalid pair.
- Run project build to ensure no regressions in TypeScript compilation path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47052091-327a-4760-bc23-d2b573bb8ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47052091-327a-4760-bc23-d2b573bb8ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

