### PR TITLE
PPG surgical audit: unify contracts, gating, and runtime diagnostics

### DIFF
--- a/src/components/VitalSign.tsx
+++ b/src/components/VitalSign.tsx
@@ -152,7 +152,7 @@ const VitalSign = ({
       )}
       onClick={handleClick}
     >
-      <div className="text-[11px] font-medium uppercase tracking-wider text-black/70 mb-1">
+      <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/95 drop-shadow-[0_1px_8px_rgba(255,255,255,0.12)]">
         {label}
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen
- unifica contratos de runtime y hace el pipeline de vitales V3-first para SpO2/BP
- endurece gating de persistencia y análisis AI según calidad/calibración reales
- expone diagnósticos de cámara, ROI, fuente ganadora y clasificaciones RR en monitor/debug

## Cambios principales
- `PPGSignalProcessor`, `SignalSourceRanker`, `TileFusionEngine` y `SignalQualityEstimator` ahora exponen explainability adicional: `selectedROI`, `roiStability`, `winningReason`, `confidencePerSignal` y flags `usableFor*`
- `VitalSignsProcessor` deja una sola ruta runtime para ritmo y publica SpO2/BP/biomarcadores con contratos/gating coherentes
- `HeartBeatProcessor` guarda amplitud real y clasificaciones RR (`clean/noisy/ectopic_candidate/...`)
- `useSaveMeasurement` y `useHealthAnalysis` solo operan con outputs realmente habilitados; el edge function `analyze-vitals` también valida esos estados
- UI/Debug: se elimina la unidad falsa `μV`, se muestran torch/FPS/cámara reales y más contexto clínico/técnico en el panel de debug

## Validación
- `npm install`
- `npm run test:run`
- `npm run build`

## Notas
- Los módulos legacy siguen existiendo para compatibilidad de wizard/reset, pero ya no dominan la ruta operativa principal.
- El warning de bundle grande sigue presente en build y queda como follow-up de performance, no como bloqueo funcional.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-312ae1da-d547-4dd7-b7e8-494ef4322b41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-312ae1da-d547-4dd7-b7e8-494ef4322b41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

