### PR TITLE
FIX: Eliminar duplicado EMA_ALPHA_MAX

### DIFF
--- a/src/constants/processing.ts
+++ b/src/constants/processing.ts
@@ -1261,9 +1261,6 @@ export const EMA_MULTIPLIER_MED = 0.5;
 /** Multiplicador EMA para cambio bajo */
 export const EMA_MULTIPLIER_LOW = 1.5;
 
-/** Alpha EMA máximo */
-export const EMA_ALPHA_MAX = 0.4;
-
 /** BPM mínimo para HR válido */
 export const HR_MIN_BPM = 35;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small constants cleanup with no algorithm changes beyond eliminating a conflicting duplicate export; low risk aside from any code that implicitly relied on the removed value.
> 
> **Overview**
> Removes a duplicate export of `EMA_ALPHA_MAX` from `src/constants/processing.ts`, leaving the single canonical `EMA_ALPHA_MAX = 0.12` used by the adaptive EMA smoothing logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5bd4ce801ec26ab1eceae10a9ca64e71640a1ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->